### PR TITLE
Restore ChatKit domain key configuration

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -1,9 +1,14 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
 import js from "@eslint/js";
 import globals from "globals";
 import reactHooks from "eslint-plugin-react-hooks";
 import reactRefresh from "eslint-plugin-react-refresh";
 import tseslint from "@typescript-eslint/eslint-plugin";
 import tsParser from "@typescript-eslint/parser";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default [
   js.configs.recommended,
@@ -13,6 +18,8 @@ export default [
       parser: tsParser,
       parserOptions: {
         projectService: true,
+        project: [path.join(__dirname, "tsconfig.json")],
+        tsconfigRootDir: __dirname,
         ecmaFeatures: {
           jsx: true,
         },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "lint": "eslint . --ext ts,tsx"
+    "lint": "eslint ."
   },
   "engines": {
     "node": ">=18.18",

--- a/frontend/src/components/Home.tsx
+++ b/frontend/src/components/Home.tsx
@@ -1,5 +1,6 @@
 // frontend/src/components/Home.tsx
 import { ChatKit, useChatKit } from "@openai/chatkit-react";
+import { CHATKIT_API_DOMAIN_KEY, CHATKIT_API_URL } from "../lib/config";
 
 type Props = {
   scheme: "light" | "dark";
@@ -9,23 +10,42 @@ type Props = {
 export default function Home({ scheme }: Props) {
   const { control } = useChatKit({
     api: {
-      // İlk token
-      getClientSecret: async () => {
-        const r = await fetch("/api/chatkit/start", { method: "POST" });
-        if (!r.ok) throw new Error(`start failed: ${r.status}`);
-        const data = await r.json();
-        return data.client_secret as string; // <-- string döndür
-      },
-      // Yenileme (opsiyonel ama iyi pratik)
-      refreshClientSecret: async ({ currentClientSecret }) => {
-        const r = await fetch("/api/chatkit/refresh", {
+      url: CHATKIT_API_URL,
+      domainKey: CHATKIT_API_DOMAIN_KEY,
+      getClientSecret: async (currentClientSecret) => {
+        const endpoint = currentClientSecret
+          ? "/api/chatkit/refresh"
+          : "/api/chatkit/start";
+
+        const response = await fetch(endpoint, {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ currentClientSecret }),
+          headers: currentClientSecret
+            ? { "Content-Type": "application/json" }
+            : undefined,
+          body: currentClientSecret
+            ? JSON.stringify({ currentClientSecret })
+            : undefined,
         });
-        if (!r.ok) throw new Error(`refresh failed: ${r.status}`);
-        const data = await r.json();
-        return data.client_secret as string; // <-- string döndür
+
+        if (!response.ok) {
+          throw new Error(
+            `${currentClientSecret ? "refresh" : "start"} failed: ${
+              response.status
+            }`,
+          );
+        }
+
+        const data: unknown = await response.json();
+        const clientSecret =
+          data && typeof data === "object"
+            ? (data as { client_secret?: unknown }).client_secret
+            : undefined;
+
+        if (typeof clientSecret !== "string" || clientSecret.length === 0) {
+          throw new Error("Response missing client_secret");
+        }
+
+        return clientSecret;
       },
     },
     theme: { colorScheme: scheme },


### PR DESCRIPTION
## Summary
- pass the configured ChatKit domain key and API URL into the Home component session bootstrap
- update the frontend lint script so it works with the current ESLint flat config setup
- configure the ESLint parser with the project path so TypeScript-aware rules can run

## Testing
- `npm --prefix frontend run lint` *(fails: existing TypeScript ESLint rules report unsafe `any` usage and config coverage issues)*

------
https://chatgpt.com/codex/tasks/task_e_68e53666dac8833384f07ad7137d9939